### PR TITLE
Feat/FID-1051: added mobile-unimarc style

### DIFF
--- a/packages/mechanic/FormatOptions.ts
+++ b/packages/mechanic/FormatOptions.ts
@@ -1,5 +1,3 @@
-
-
 export interface FormatOptions {
   currencyFormat: Intl.NumberFormat;
   locales: string[] | string;

--- a/packages/mechanic/Part.ts
+++ b/packages/mechanic/Part.ts
@@ -1,9 +1,6 @@
 import { FormatOptions } from "./FormatOptions";
 import { Path } from "./Path";
 import { TypePart } from "./TypePart";
-
-
-
 export class Part {
   constructor(
     readonly type: TypePart,
@@ -22,9 +19,7 @@ export class Part {
   }
 }
 
-
 export const part = (
   type: TypePart,
   value: string | ((group: Record<string, string>, options: FormatOptions) => string)
 ) => new Part(type, value);
-

--- a/packages/mechanic/Suffixes.ts
+++ b/packages/mechanic/Suffixes.ts
@@ -1,0 +1,14 @@
+const pr = new Intl.PluralRules('en-US', { type: 'ordinal' });
+
+const suffixes = new Map([
+  ['one',   'ra'],
+  ['two',   'da'],
+  ['few',   'ra'],
+  ['other', 'ta'],
+]);
+
+export const formatOrdinals = (n: any) => {
+  const rule = pr.select(n);
+  const suffix = suffixes.get(rule);
+  return `${suffix}`;
+};

--- a/packages/mechanic/Template.ts
+++ b/packages/mechanic/Template.ts
@@ -2,8 +2,6 @@ import { FormatOptions } from "./FormatOptions";
 import { Part } from "./Part";
 import { Path } from "./Path";
 
-
-
 export class Template {
   constructor(
     private template: { raw: readonly string[] | ArrayLike<string>; },
@@ -31,7 +29,6 @@ export class Template {
   }
 
 }
-
 
 export const template = (
   template: { raw: readonly string[] | ArrayLike<string> },

--- a/packages/mechanic/TypePart.ts
+++ b/packages/mechanic/TypePart.ts
@@ -1,4 +1,3 @@
-
 export type TypePart = "discount" |
   "discountAmount" |
   "literal" |
@@ -9,4 +8,6 @@ export type TypePart = "discount" |
   "ref" |
   "input" |
   "nOffer" |
-  "new_line";
+  "new_line" |
+  "variableOffer" |
+  "amountWithSuffix";

--- a/packages/mechanic/mechanics-expressions.ts
+++ b/packages/mechanic/mechanics-expressions.ts
@@ -1,10 +1,9 @@
 import { Part } from "./Part";
 import { template, Template } from "./Template";
-
-
+import { formatOrdinals } from './Suffixes'
 export interface Expressions {
   exp: RegExp
-  template: Template
+  template: Template[]
 }
 
 export const discount = new Part("discount", ({ discount }) => [{ type: "discount", value: discount }, { type: "percentSign", value: `%` }]);
@@ -17,42 +16,57 @@ export const newLine = new Part("new_line", () => `\n`)
 export const nOffer = new Part("nOffer", ({ nOffer }, { currencyFormat }) => currencyFormat.formatToParts(Number(nOffer)))
 export const discountAmount = new Part("discountAmount", ({ discountAmount }, { currencyFormat }) => currencyFormat.formatToParts(Number(discountAmount)))
 export const minimumAmount = new Part("minimumAmount", ({ minimumAmount }, { currencyFormat }) => currencyFormat.formatToParts(Number(minimumAmount)))
+const variableOffer = new Part(
+  "variableOffer", 
+  ({ variableOffer }, { currencyFormat }) => 
+  parseInt(variableOffer, 10) > 100 ? 
+  currencyFormat.formatToParts(Number(variableOffer)) :
+  [{ type: "variableOffer", value: variableOffer }, { type: "percentSign", value: `%` }]
+  )
+const amountWithSuffix = new Part(
+    "amountWithSuffix", 
+    ({amountWithSuffix}) => [
+      { type: "amountWithSuffix", value: amountWithSuffix }, 
+      { type: "suffix", value: `${formatOrdinals(parseInt(amountWithSuffix))}` }
+    ])
 
 type MechanicId = string
 type StyleId = string
 type MechanicTemplates = Record<MechanicId, Expressions | Expressions[]>
 type StylesMechanicTemplates = Record<StyleId, MechanicTemplates>
+  
+// TODO: preguntar cual es el maximo de unidades
 
 const defaultMechanicExpressions: MechanicTemplates = {
   "1": {
     exp: /^(?<discount>\d+)$/,
-    template: template`${discount} Descuento`,
+    template: [template`${discount} Descuento`],
+  },
+  "2": {
+    exp: /^(?<nProducts>\d+)\*(?<m>\d+)$/,
+    template: [template`${nProducts}x${m}`],
   },
   "4": [
     {
       exp: /^(?<offer>\d+)$/,
-      template: template`${offer}`,
+      template: [template`${offer}`],
     },
     {
       exp: /^(?<offer>\d+)\*(?<ref>\d+)$/,
-      template: template`${offer} Antes: ${ref}`,
+      template: [template`${offer} Antes: ${ref}`],
     },
   ],
-  "13": {
-    exp: /^(?<input>.+)$/,
-    template: template`${input}`,
+  "7": {
+    exp: /^(?<nProducts>\d+)\*(?<offer>\d+)$/,
+    template: [template`${nProducts} x ${offer}`],
   },
   "11": {
     exp: /^(?<discountAmount>\d+)\*(?<minimumAmount>\d+)$/,
-    template: template`${discountAmount} Por una compra sobre ${minimumAmount}`,
+    template: [template`${discountAmount} Por una compra sobre ${minimumAmount}`],
   },
-  "2": {
-    exp: /^(?<nProducts>\d+)\*(?<m>\d+)$/,
-    template: template`${nProducts}x${m}`,
-  },
-  "7": {
-    exp: /^(?<nProducts>\d+)\*(?<offer>\d+)$/,
-    template: template`${nProducts} x ${offer}`,
+  "13": {
+    exp: /^(?<input>.+)$/,
+    template: [template`${input}`],
   },
 };
 
@@ -62,7 +76,28 @@ export const mechanicExpressions: StylesMechanicTemplates = {
     ...defaultMechanicExpressions,
     "11": {
       exp: /^(?<discountAmount>\d+)\*(?<minimumAmount>\d+)$/,
-      template: template`${discountAmount} de descuento${newLine}Por compras sobre ${minimumAmount}`,
+      template: [template`${discountAmount} de descuento${newLine}Por compras sobre ${minimumAmount}`],
     },
   },
-};
+  "mobile-unimarc": {
+    ...defaultMechanicExpressions,
+    "4": [
+      {
+        exp: /^(?<offer>\d+)$/,
+        template: [template`${offer}`],
+      },
+      {
+        exp: /^(?<offer>\d+)\*(?<ref>\d+)$/,
+        template: [template`${offer}${newLine}Antes: ${ref}`],
+      },
+    ],
+    "8": {
+      exp: /^(?<amountWithSuffix>\d+)\*(?<variableOffer>\d+)$/,
+      template: [template`${amountWithSuffix} UN x ${variableOffer}`, template`${variableOffer} en ${amountWithSuffix} UN`]
+    },
+    "11": {
+      exp: /^(?<discountAmount>\d+)\*(?<minimumAmount>\d+)$/,
+      template: [template`${discountAmount} de descuento${newLine}Por compras sobre ${minimumAmount}`],
+    }
+  }
+}; 

--- a/packages/mechanic/mechanics-id-supported.ts
+++ b/packages/mechanic/mechanics-id-supported.ts
@@ -3,22 +3,18 @@ export const MechanicsIdSupported = [
     "2",
     "4",
     "7",
-    "13",
+    "8",
     "11",
+    "13",
 ] as const;
 
-
 export type MechanicsId = typeof MechanicsIdSupported[number];
-
-
 export interface MechanicsMapExpression {
     "1": `${number}`
-    "4": `${number}` | `${number}*${number}`
-    "13": string
-    "11": `${number}*${number}`
     "2": `${number}*${number}`
+    "4": `${number}` | `${number}*${number}`
     "7": `${number}*${number}`
+    "8": `${number}*${number}`
+    "11": `${number}*${number}`
+    "13": string
 }
-
-// +7
-// +2

--- a/packages/mechanic/mechanics.spec.ts
+++ b/packages/mechanic/mechanics.spec.ts
@@ -1,6 +1,4 @@
 import { Mechanics } from "./mechanics";
-import { discount } from "./mechanics-expressions";
-import { template } from "./Template";
 
 describe("Mechanics", () => {
   it("should expect error in parseToParts", () => {
@@ -48,7 +46,7 @@ describe("Mechanics", () => {
     `);
   });
 
-  it("format MechanicsId 4", () => {
+  it("format MechanicsId 4 full", () => {
     let mechanics = new Mechanics();
 
     expect(mechanics.format("4", "10*100")).toBe("$10 Antes: $100");
@@ -77,6 +75,24 @@ describe("Mechanics", () => {
       ]
     `);
   });
+
+  it("format MechanicsId 4 single", () => {
+    let mechanics = new Mechanics();
+
+    expect(mechanics.format("4", "100")).toBe("$100");
+    expect(mechanics.formatToParts("4", "100")).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "type": "currency",
+          "value": "$",
+        },
+        Object {
+          "type": "integer",
+          "value": "100",
+        },
+      ]
+    `);
+  })
 
   it("format MechanicsId 13", () => {
     let mechanics = new Mechanics();
@@ -277,5 +293,162 @@ describe("Mechanics", () => {
       `);
     })
 
+  });
+
+  describe("style mobile-unimarc", () => {
+
+    it("format MechanicsId 4", () => {
+      const mechanics = new Mechanics("es-CL", { style: "mobile-unimarc" });
+  
+      expect(mechanics.format("4", "10*100")).toBe("$10\nAntes: $100");
+      expect(mechanics.formatToParts("4", "10*100")).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "type": "currency",
+            "value": "$",
+          },
+          Object {
+            "type": "integer",
+            "value": "10",
+          },
+          Object {
+            "type": "new_line",
+            "value": "
+        ",
+          },
+          Object {
+            "type": "literal",
+            "value": "Antes: ",
+          },
+          Object {
+            "type": "currency",
+            "value": "$",
+          },
+          Object {
+            "type": "integer",
+            "value": "100",
+          },
+        ]
+      `);
+    });
+
+    it("should format mechanics 11", () => {
+      const mechanic = new Mechanics("es-CL", { style: "mobile-unimarc" });
+
+      expect(mechanic.format("11", "15000*125000")).toBe("$15.000 de descuento\nPor compras sobre $125.000");
+      expect(mechanic.formatToParts("11", "15000*125000")).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "type": "currency",
+            "value": "$",
+          },
+          Object {
+            "type": "integer",
+            "value": "15",
+          },
+          Object {
+            "type": "group",
+            "value": ".",
+          },
+          Object {
+            "type": "integer",
+            "value": "000",
+          },
+          Object {
+            "type": "literal",
+            "value": " de descuento",
+          },
+          Object {
+            "type": "new_line",
+            "value": "
+        ",
+          },
+          Object {
+            "type": "literal",
+            "value": "Por compras sobre ",
+          },
+          Object {
+            "type": "currency",
+            "value": "$",
+          },
+          Object {
+            "type": "integer",
+            "value": "125",
+          },
+          Object {
+            "type": "group",
+            "value": ".",
+          },
+          Object {
+            "type": "integer",
+            "value": "000",
+          },
+        ]
+      `);
+    })
+
+    it("should format mechanics 8a", () => {
+      const mechanic = new Mechanics("es-CL", { style: "mobile-unimarc" });
+
+      expect(mechanic.format("8", "2*330")).toBe("2da UN x $330");
+      expect(mechanic.formatToParts("8", "2*330")).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "type": "amountWithSuffix",
+            "value": "2",
+          },
+          Object {
+            "type": "suffix",
+            "value": "da",
+          },
+          Object {
+            "type": "literal",
+            "value": " UN x ",
+          },
+          Object {
+            "type": "currency",
+            "value": "$",
+          },
+          Object {
+            "type": "integer",
+            "value": "330",
+          },
+        ]
+      `);
+    })
+
+    it("should format mechanics 8b", () => {
+      const mechanic = new Mechanics("es-CL", { style: "mobile-unimarc" });
+
+      expect(mechanic.format("8", "2*30")).toBe("30% en 2da UN");
+      expect(mechanic.formatToParts("8", "2*30")).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "type": "variableOffer",
+            "value": "30",
+          },
+          Object {
+            "type": "percentSign",
+            "value": "%",
+          },
+          Object {
+            "type": "literal",
+            "value": " en ",
+          },
+          Object {
+            "type": "amountWithSuffix",
+            "value": "2",
+          },
+          Object {
+            "type": "suffix",
+            "value": "da",
+          },
+          Object {
+            "type": "literal",
+            "value": " UN",
+          },
+        ]
+      `);
+    })
   });
 });

--- a/packages/mechanic/mechanics.ts
+++ b/packages/mechanic/mechanics.ts
@@ -1,13 +1,10 @@
 import { mechanicExpressions } from "./mechanics-expressions";
-import { Template } from "./Template";
 import { Path } from "./Path";
-
 
 export type MechanicsOption = {
   style?: string
   currencyFormat?: Intl.NumberFormatOptions
 }
-
 
 export class Mechanics {
   private currencyFormatOptions: Intl.NumberFormatOptions;
@@ -22,6 +19,12 @@ export class Mechanics {
       ...this.options?.currencyFormat,
     };
     this.currencyFormat = new Intl.NumberFormat(locales, this.currencyFormatOptions);
+  }
+
+  expEvaluation(mechanicsId: string, mechanicsText: string){
+    const str = mechanicsText.split('*')
+    if(mechanicsId === '8' && parseInt(str[1], 10) < 100) return 1
+    return 0
   }
 
   formatToParts(mechanicsId: string, mechanicsText: string): Path[] {
@@ -43,7 +46,8 @@ export class Mechanics {
       const resultExp = exp.exp.exec(mechanicsText);
       if (resultExp) {
         const group = resultExp.groups ?? {};
-        return exp.template.renderParts(group, { currencyFormat: this.currencyFormat, locales: this.locales });
+        const template = this.expEvaluation(mechanicsId, mechanicsText)
+        return exp.template[template].renderParts(group, { currencyFormat: this.currencyFormat, locales: this.locales });
       }
     }
 


### PR DESCRIPTION
## Updates 💡

Added style for unimarc mobile app and changed structure of Expressions

- Added _variableOffer_ and _amountWithSuffix_
- Added mobile-unimarc style with mechanics 4-modified, 8a, 8b and 11-modified
- Suffix file
- Now Expressions change to be Temaplate to Template[]

## Checklist ✅

- [x] New feature (non-breaking change which adds functionality)

## Commits 🌐
- [1084596](https://github.com/reigncl/reign-utils/commit/108459670d37ea960a1e6ca8bcbe36fa961d8e0e) - feat: added mobile-unimarc style

## Tickets 🎟
[FID-1051](https://it-smu.atlassian.net/jira/software/c/projects/FID/boards/66?modal=detail&selectedIssue=FID-1051)

## Screeshots 🖼
![image](https://user-images.githubusercontent.com/103453835/171652576-0aff322c-0bcc-4c6e-be8d-f1c2c7bdc977.png)
